### PR TITLE
Add partial support for Pangu on iOS 7.1.2.

### DIFF
--- a/safestrat.c
+++ b/safestrat.c
@@ -92,9 +92,12 @@ int main(int argc, char **argv) {
     if (!(force || test_volume_down()))
         return 0;
     enable_usb();
-    execl("/usr/sbin/sshd", "/usr/sbin/sshd", "-D", NULL);
-    printf("exec fail :(\n");
-    return 1;
+    //execl("/usr/sbin/sshd", "/usr/sbin/sshd", "-D", NULL);
+    kill(14, SIGSTOP);
+    system("/usr/sbin/sshd -D");
+    kill(14, SIGCONT);
+    printf("up and running!\n");
+    return 0;
 usage:
     printf("usage: safestrat [force]\n");
     return 1;

--- a/safestrat.c
+++ b/safestrat.c
@@ -93,9 +93,11 @@ int main(int argc, char **argv) {
         return 0;
     enable_usb();
     //execl("/usr/sbin/sshd", "/usr/sbin/sshd", "-D", NULL);
-    kill(14, SIGSTOP);
+    if (kCFCoreFoundationVersionNumber > 847.22 && kCFCoreFoundationVersionNumber < 1140.0)
+        kill(14, SIGSTOP);
     system("/usr/sbin/sshd -D");
-    kill(14, SIGCONT);
+    if (kCFCoreFoundationVersionNumber > 847.22 && kCFCoreFoundationVersionNumber < 1140.0)
+        kill(14, SIGCONT);
     printf("up and running!\n");
     return 0;
 usage:


### PR DESCRIPTION
Pangu on iOS 7.1.x doesn't wait for binaries in /etc/rc.d to finish, so we have to halt the boot process ourselves.
